### PR TITLE
onPersonalUrls should be static - breaks strict standards otherwise

### DIFF
--- a/PhpbbAuthHooks.php
+++ b/PhpbbAuthHooks.php
@@ -21,7 +21,7 @@
 
 class PhpbbAuthHooks {
 
-	public function onPersonalUrls( array &$personal_urls, Title $title, SkinTemplate $skin ) {
+	public static function onPersonalUrls( array &$personal_urls, Title $title, SkinTemplate $skin ) {
 		global $wgPhpBBAuthForumDirectory;
 
 		if ( array_key_exists( 'login', $personal_urls ) ) {


### PR DESCRIPTION
Minor tweak - on some servers, not adhering to strict standards will not load the page